### PR TITLE
The browser in Android 2.3.3 doesn't ignore spaces around the "=" causin...

### DIFF
--- a/src/controls/placesaver.js
+++ b/src/controls/placesaver.js
@@ -39,7 +39,7 @@ Monocle.Controls.PlaceSaver = function (bookId) {
       expires = "; expires="+d.toGMTString();
     }
     var path = "; path=/";
-    document.cookie = p.prefix + key + " = " + value + expires + path;
+    document.cookie = p.prefix + key + "=" + value + expires + path;
     return value;
   }
 


### PR DESCRIPTION
...g getCookie to never find the key. Instead, save the cookie without spaces.
