### PR TITLE
Zero width in marginal pannels

### DIFF
--- a/src/panels/marginal.js
+++ b/src/panels/marginal.js
@@ -39,8 +39,10 @@ Monocle.Panels.Marginal = function (flipper, evtCallbacks) {
     var sheaf = page.m.sheafDiv;
     var bw = sheaf.offsetLeft;
     var fw = page.offsetWidth - (sheaf.offsetLeft + sheaf.offsetWidth);
-    bw = Math.floor(((bw - 2) / page.offsetWidth) * 10000 / 100 ) + "%";
-    fw = Math.floor(((fw - 2) / page.offsetWidth) * 10000 / 100 ) + "%";
+    bw = Math.round(((bw - 2) / page.offsetWidth) * 10000 / 100 );
+    fw = Math.round(((fw - 2) / page.offsetWidth) * 10000 / 100 );
+    bw = Math.max(bw, 5) + "%";
+    fw = Math.max(fw, 5) + "%";
     p.panels.forwards.properties.div.style.width = fw;
     p.panels.backwards.properties.div.style.width = bw;
   }


### PR DESCRIPTION
From my own tests, the width of marginal panels was always zero. Investigating this issue, I realized that setWidths function was using the method Math.floor. Since we expect that bw and fw will be lower in some cases, when applying the Math.floor, the result is zero.

So my suggestion is:
1) Use Math.round instead of Math.floor (it's more realistic).
2) Configure a min value (for instance, 5) to prevent these values beeing very low (and users cannot interact with these marginal panels)
