### PR TITLE
stencil masks should have absolute positions to be placed correctly on the screen

### DIFF
--- a/src/controls/stencil.js
+++ b/src/controls/stencil.js
@@ -171,7 +171,8 @@ Monocle.Controls.Stencil = function (reader, behaviorClasses) {
         left: cr.left+"px",
         top: cr.top+"px",
         width: cr.width+"px",
-        height: cr.height+"px"
+        height: cr.height+"px",
+        position: 'absolute'
       });
       mask.stencilRect = cr;
     }


### PR DESCRIPTION
Minor change on stencil mask style to add position: 'absolute'.
