### PR TITLE
Move for not all code paths hitting method

### DIFF
--- a/src/flippers/scroller.js
+++ b/src/flippers/scroller.js
@@ -100,12 +100,12 @@ Monocle.Flippers.Scroller = function (reader, setPageFn) {
       }
       stepFn();
     }
+    p.turning = false;
   }
 
 
   function turned() {
-    p.turning = false;
-    p.reader.dispatchEvent('monocle:turn');
+  p.reader.dispatchEvent('monocle:turn');
   }
 
 


### PR DESCRIPTION
Not all code paths were hitting this (and calling turned method) in the event that a TOC Link
was hit while residing on the page the link points to (such as the first page of a chapter), it did not call the path to launch the turned() method.  Moved it up here and that fixed it for us.  The issue
depends on the fact that we load the entire book at once, as well.  Cannot find any issues with this code move on our end (ie didn't seem to create any new bugs for us).
