### PR TITLE
Fix pagination for Chrome 22+ when zooming

### DIFF
--- a/src/dimensions/columns.js
+++ b/src/dimensions/columns.js
@@ -96,7 +96,7 @@ Monocle.Dimensions.Columns = function (pageDiv) {
   // Taken from https://github.com/yonran/detect-zoom
   function zoomWebkit() {
     var container = document.createElement('div')
-      , div = document.createElement('div');
+      , div = document.createElement('div')
       , important = function(str){ return str.replace(/;/g, " !important;"); };
 
     container.setAttribute('style', important('width:0; height:0; overflow:hidden; visibility:hidden; position: absolute;'));


### PR DESCRIPTION
Hi,

when using Monocle on Chrome 22+ (with sub-pixel rendering) and zooming (in or out), the  pages can be cut on the left or right when we advance far in a component.This commit can be the start of a fix for this issue.
