### PR TITLE
Fix pagination for Chrome 22+ when zooming

### DIFF
--- a/src/dimensions/columns.js
+++ b/src/dimensions/columns.js
@@ -97,7 +97,12 @@ Monocle.Dimensions.Columns = function (pageDiv) {
     var elem = p.page.m.sheafDiv;
     var w = elem.clientWidth;
     if (elem.getBoundingClientRect) { w = elem.getBoundingClientRect().width; }
-    if (Monocle.Browser.env.roundPageDimensions) { w = Math.round(w); }
+    if (Monocle.Browser.is.WebKit) {
+      var zoom = p.reader.getWebKitScaleFactor();
+      w = Math.round(w * zoom) / zoom;
+    } else if (Monocle.Browser.env.roundPageDimensions) {
+      w = Math.round(w);
+    }
     return { col: w, width: w + k.GAP, height: elem.clientHeight }
   }
 


### PR DESCRIPTION
Hi,

When using zoom in/out in chrome 22+ with sub-pixel rendering, pages can be cut on the left or right.
A first try to fix it can be found here : https://github.com/joseph/Monocle/pull/146

This is a new version reducing DOM access by computed webkit scale value only when value is updated (updating zoom fire a window resize event).

I find the code a little dirty because of the addition of a specific value for one engine but I don't how how you handle those cases.
