### PR TITLE
Adding SVG to elements which max-height = 95%

### DIFF
--- a/src/core/formatting.js
+++ b/src/core/formatting.js
@@ -297,7 +297,7 @@ Monocle.Formatting.DEFAULT_STYLE_RULES = [
   "html#RS\\:monocle body * {" +
     "max-width: 100% !important;" +
   "}",
-  "html#RS\\:monocle img, html#RS\\:monocle video, html#RS\\:monocle object {" +
+  "html#RS\\:monocle img, html#RS\\:monocle video, html#RS\\:monocle object, html#RS\\:monocle svg {" +
     "max-height: 95% !important;" +
     "height: auto !important;" +
   "}"


### PR DESCRIPTION
From my own tests, when using SVG to include images, depending on the size of the object/SVG, it may break to next page.

Saying this, I suggest to include SVG in the list of tags that Monocle prevent to fill more than 95% of the available space.
