### PR TITLE
Stop event propagation when dismissing popover controls

### DIFF
--- a/src/core/reader.js
+++ b/src/core/reader.js
@@ -537,7 +537,7 @@ Monocle.Reader = function (node, bookData, options, onLoadCallback) {
       overlay.listeners = Monocle.Events.listenForContact(
         overlay,
         {
-          start: function (evt) { if (!onControl(evt)) { hideControl(ctrl); } },
+          start: function (evt) { if (!onControl(evt)) { evt.stopPropagation(); hideControl(ctrl); } },
           move: function (evt) { if (!onControl(evt)) { evt.preventDefault(); } }
         }
       );


### PR DESCRIPTION
Here's the change I mentioned in the email to the list.  It fixes the problem I noticed, but I don' t know what other ramifications this might have.  I haven't done testing to find out.
