### PR TITLE
`Monocle.Flippers.Scroller.speed` isn't used anywhere

### DIFF
--- a/src/flippers/scroller.js
+++ b/src/flippers/scroller.js
@@ -4,7 +4,7 @@ Monocle.Flippers.Scroller = function (reader, setPageFn) {
   var k = API.constants = API.constructor;
   var p = API.properties = {
     pageCount: 1,
-    duration: 300
+    duration: k.speed
   }
 
 
@@ -121,7 +121,7 @@ Monocle.Flippers.Scroller = function (reader, setPageFn) {
   return API;
 }
 
-Monocle.Flippers.Scroller.speed = 200; // How long the animation takes
+Monocle.Flippers.Scroller.speed = 300; // How long the animation takes
 Monocle.Flippers.Scroller.rate = 20; // frame-rate of the animation
 Monocle.Flippers.Scroller.FORWARDS = 1;
 Monocle.Flippers.Scroller.BACKWARDS = -1;


### PR DESCRIPTION
From what I can tell, this constant isn't referred to anywhere https://github.com/joseph/Monocle/blob/master/src/flippers/scroller.js#L124.

It is the same as "speed" here? https://github.com/joseph/Monocle/blob/master/src/flippers/scroller.js#L7
