### PR TITLE
prevent event propagation on scrubber interaction

### DIFF
--- a/src/controls/scrubber.js
+++ b/src/controls/scrubber.js
@@ -105,6 +105,7 @@ Monocle.Controls.Scrubber = function (reader) {
     }
 
     var startFn = function (evt) {
+      evt.stopPropagation();
       bubble.style.display = "block";
       moveEvt(evt);
       cntrListeners = Monocle.Events.listenForContact(


### PR DESCRIPTION
When interacting with the scrubber and the scrubber was positioned over the book - the page turn event would fire as you interact with the book.

This issue can be viewed currently at http://test.monoclejs.com/test/controls/index.html
