### PR TITLE
add radix parameter to parseInt

### DIFF
--- a/src/core/billboard.js
+++ b/src/core/billboard.js
@@ -84,14 +84,14 @@ Monocle.Billboard = function (reader) {
     var w = (p.inner.scrollWidth - p.inner.offsetWidth);
     var h = (p.inner.scrollHeight - p.inner.offsetHeight);
     if (s[0].match(/^\d+$/)) {
-      l = Math.max(0, parseInt(s[0]) - (p.inner.offsetWidth / 2));
+      l = Math.max(0, parseInt(s[0], 10) - (p.inner.offsetWidth / 2));
     } else if (s[0] == 'center') {
       l = w / 2;
     } else if (s[0] == 'right') {
       l = w;
     }
     if (s[1] && s[1].match(/^\d+$/)) {
-      t = Math.max(0, parseInt(s[1]) - (p.inner.offsetHeight / 2));
+      t = Math.max(0, parseInt(s[1], 10) - (p.inner.offsetHeight / 2));
     } else if (!s[1] || s[1] == 'center') {
       t =  h / 2;
     } else if (s[1] == 'bottom') {

--- a/src/core/styles.js
+++ b/src/core/styles.js
@@ -66,7 +66,7 @@ Monocle.Styles = {
     while (props.length && !matrix) {
       matrix = currStyle[props.shift()];
     }
-    return parseInt(matrix.match(re)[1]);
+    return parseInt(matrix.match(re)[1], 10);
   },
 
 

--- a/src/flippers/slider.js
+++ b/src/flippers/slider.js
@@ -321,7 +321,7 @@ Monocle.Flippers.Slider = function (reader) {
     if (!options.duration) {
       duration = 0;
     } else {
-      duration = parseInt(options.duration);
+      duration = parseInt(options.duration, 10);
     }
 
     if (Monocle.Browser.env.supportsTransition) {


### PR DESCRIPTION
While I'm not a huge fan of parseInt in most scenarios and prefer Number() over parseInt, I feel it's important to include the radix parameter because I've also run into subtle bugs of numbers being parse incorrectly due to radix being guessed at 2 or 8.

Not sure how you feel about this or how your preference stands but I feel it's more than dogma to ensure that the radix parameter is provided…but I also prefer to use Number() in most scenarios. :)

Let me know if this makes sense to pull in.
