### PR TITLE
boolean cleanup

### DIFF
--- a/src/compat/gala.js
+++ b/src/compat/gala.js
@@ -63,7 +63,7 @@ Gala.dispatch = function (elem, evtType, data, cancelable) {
       defaultPrevented: false,
       preventDefault: function () { evt.defaultPrevented = true; }
     }
-    var q, processQueue = Gala.IE_INVOCATION_QUEUE.length == 0;
+    var q, processQueue = Gala.IE_INVOCATION_QUEUE.length === 0;
     for (var i = 0, ii = evtHandlers.length; i < ii; ++i) {
       q = { elem: elem, evtType: evtType, handler: evtHandlers[i], evt: evt }
       Gala.IE_INVOCATION_QUEUE.push(q);
@@ -281,7 +281,7 @@ Gala.Cursor = function (evt) {
 
   function initialize() {
     var ci =
-      evt.type.indexOf('mouse') == 0 ? evt :
+      evt.type.indexOf('mouse') === 0 ? evt :
       ['touchstart', 'touchmove'].indexOf(evt.type) >= 0 ? evt.targetTouches[0] :
       ['touchend', 'touchcancel'].indexOf(evt.type) >= 0 ? evt.changedTouches[0] :
       null;

--- a/src/controls/stencil.js
+++ b/src/controls/stencil.js
@@ -366,7 +366,7 @@ Monocle.Controls.Stencil.Links = function (stencil) {
     }
     // URLs with a different protocol or domain are always external.
     //console.log("Domain test: %s <=> %s", origin, href);
-    if (href.indexOf(origin) != 0) {
+    if (href.indexOf(origin) !== 0) {
       return ext;
     }
 
@@ -376,7 +376,7 @@ Monocle.Controls.Stencil.Links = function (stencil) {
       topPath += '/';
     }
     //console.log("Sub-path test: %s <=> %s", topPath, path);
-    if (path.indexOf(topPath) == 0) {
+    if (path.indexOf(topPath) === 0) {
       return { internal: path.substring(topPath.length) }
     }
 
@@ -385,7 +385,7 @@ Monocle.Controls.Stencil.Links = function (stencil) {
     var cmptIds = stencil.properties.reader.getBook().properties.componentIds;
     for (var i = 0, ii = cmptIds.length; i < ii; ++i) {
       //console.log("Component test: %s <=> %s", cmptIds[i], path);
-      if (path.indexOf(cmptIds[i]) == 0) {
+      if (path.indexOf(cmptIds[i]) === 0) {
         return { internal: path }
       }
     }

--- a/src/core/billboard.js
+++ b/src/core/billboard.js
@@ -26,7 +26,7 @@ Monocle.Billboard = function (reader) {
       elem.naturalWidth || elem.offsetWidth,
       elem.naturalHeight || elem.offsetHeight
     ];
-    if (options.closeButton != false) {
+    if (options.closeButton) {
       var cBtn = p.cntr.dom.append('div', k.CLS.closeButton);
       Monocle.Events.listenForTap(cBtn, hide);
     }

--- a/src/core/book.js
+++ b/src/core/book.js
@@ -134,7 +134,7 @@ Monocle.Book = function (dataSource, preloadWindow) {
     }
 
     if (result.page < 1) {
-      if (cIndex == 0) {
+      if (cIndex === 0) {
         // On first page of book.
         result.page = 1;
         result.boundarystart = true;

--- a/src/core/place.js
+++ b/src/core/place.js
@@ -143,7 +143,7 @@ Monocle.Place = function () {
 
 
   function onFirstPageOfBook() {
-    return p.component.properties.index == 0 && pageNumber() == 1;
+    return p.component.properties.index === 0 && pageNumber() == 1;
   }
 
 

--- a/src/core/reader.js
+++ b/src/core/reader.js
@@ -552,7 +552,7 @@ Monocle.Reader = function (node, bookData, options, onLoadCallback) {
 
   function showingControl(ctrl) {
     var controlData = dataForControl(ctrl);
-    return controlData.hidden == false;
+    return (!controlData.hidden);
   }
 
 

--- a/src/flippers/slider.js
+++ b/src/flippers/slider.js
@@ -202,7 +202,7 @@ Monocle.Flippers.Slider = function (reader) {
 
 
   function onGoingForward(x) {
-    if (p.nextPageReady == false) {
+    if (!p.nextPageReady) {
       prepareNextPage(function () { lifted(x); }, resetTurnData);
     } else {
       lifted(x);


### PR DESCRIPTION
- Compare 0 using ===
- Change foo == false to (!foo)
- Change foo == true to just (foo)

I know we talked about your feelings of == vs === but I thought I would push this anyways for discussion.

While I have not personally hit bugs do to these comparisons, I do prefer (foo) and (!foo) vs (foo == false || foo == true). The biggest reason I prefer this is for clarity of what is acceptable in scenarios but then again, I also compare against length using (arr.length).

The second reason I'm pushing this commit is because I wanted to also start a discussion about including jshint to help ensure consistency, etc across the javascript.

While jshint is very customizable - one area that it doesn't really waver is comparisons of (== true) (== false) and (== 0) which to me makes sense. This may be dogmatic but I think it's more about clarity.

I would like to push a jshint file in another commit which will allow quickly 'linting' the js based on your preference and what styles I noted already present in the application.

Thoughts?
