### PR TITLE
include specific css for IE10, Win8 & Surface

### DIFF
--- a/src/core/formatting.js
+++ b/src/core/formatting.js
@@ -279,6 +279,12 @@ Monocle.Formatting.DEFAULT_STYLE_RULES = [
     "width: 100% !important;" +
     "position: absolute !important;" +
     "-webkit-text-size-adjust: none;" +
+    "-ms-touch-action: none;" +
+    "-ms-content-zooming: none;" +
+    "-ms-content-zoom-chaining: chained;" +
+    "-ms-content-zoom-limit-min: 100%;" +
+    "-ms-content-zoom-limit-max: 100%;" +
+    "-ms-touch-select: none;" +
   "}",
   "html#RS\\:monocle body * {" +
     "max-width: 100% !important;" +


### PR DESCRIPTION
Internet explorer on the surface and on windows8 touch devices require css to prevent pinch and zoom along with a declaration to prevent touch selections of text
