### PR TITLE
silk browser should not listen to multiple events

### DIFF
--- a/src/compat/gala.js
+++ b/src/compat/gala.js
@@ -321,7 +321,7 @@ Gala.Pointers.ENV = {
   // everyone will just adopt the pointer spec.
   //
   noMouse: (function () {
-    var mobileRegex = /mobile|tablet|ip(ad|hone|od)|android/i;
+    var mobileRegex = /mobile|tablet|ip(ad|hone|od)|android|silk/i;
     return (
       ('ontouchstart' in window) &&
       !!navigator.userAgent.match(mobileRegex)


### PR DESCRIPTION
It appears that under some scenarios the silk browser masquerades as a desktop instead of an android device.

silk has been added as part of the noMouse detection regex to filter out the kindle devices as not having a mouse.
