### PR TITLE
fixed undefined reference to BIF.dispatch

### DIFF
--- a/src/core/reader.js
+++ b/src/core/reader.js
@@ -353,7 +353,7 @@ Monocle.Reader = function (node, bookData, options, onLoadCallback) {
         componentId: place.componentId(),
         percent: place.percentageThrough()
       }
-      BIF.dispatch('monocle:position', { place: place });
+      dispatchEvent('monocle:position', { place: place });
     }
   }
 


### PR DESCRIPTION
Hello,

I'm building monocle from the master branch, and it started throwing errors about undefined reference to BIF.dispatch. Looking around the code, I haven't found any other reference to BIF namespace, so it appears to me that it should be just a normal dispatchEvent() call, which is what this pull request is fixing.

Please let me know if I'm missing something, and BIF namespace should rather be known to monocle.
