### PR TITLE
added ellipsis truncation to overflows to TOC entries

### DIFF
--- a/styles/monoctrl.css
+++ b/styles/monoctrl.css
@@ -30,6 +30,9 @@ ol.monelem_controls_contents_list {
 }
 
 li.monelem_controls_contents_chapter {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
   list-style: none;
   line-height: 220%;
   padding-left: 1em;


### PR DESCRIPTION
For indented entries in the TOC, if the chapter name is longer than the width of the TOC box, the name will wrap to the second line and be unaligned. Instead of wrapping, just truncate the chapter name using text-overflow: ellipsis.

example: I modified a chapter title in the Dickens example (http://test.monoclejs.com/test/showcase/02-dickens/index.html)

![screen shot 2013-09-13 at 1 00 02 pm](https://f.cloud.github.com/assets/1103905/1141195/18bf5d56-1caf-11e3-8450-a3eeaaef13ac.png)

becomes

![screen shot 2013-09-13 at 1 00 59 pm](https://f.cloud.github.com/assets/1103905/1141199/3ade491a-1caf-11e3-9c27-2b52d2943ff8.png)
