### PR TITLE
Detect ie 11 properly

### DIFF
--- a/src/compat/browser.js
+++ b/src/compat/browser.js
@@ -12,7 +12,11 @@ Monocle.Browser.uaMatch = function (test) {
 // Detect the browser engine and set boolean flags for reference.
 //
 Monocle.Browser.is = {
-  IE: !!(window.attachEvent && !Monocle.Browser.uaMatch('Opera')),
+  IE: !!(
+    (window.attachEvent && !Monocle.Browser.uaMatch('Opera')) ||
+    // IE 11
+    (window.navigator.appName == 'Netscape' && Monocle.Browser.uaMatch('Trident'))
+  ),
   Opera: Monocle.Browser.uaMatch('Opera'),
   WebKit: Monocle.Browser.uaMatch(/Apple\s?WebKit/),
   Gecko: Monocle.Browser.uaMatch('Gecko') && !Monocle.Browser.uaMatch('KHTML'),


### PR DESCRIPTION
In IE 11, the user agent string was changed and attacheEvent was also
removed. This does not directly depend on the user agent string as this
has changed a bit.
