### PR TITLE
fix IE 11 clipping of books

### DIFF
--- a/src/compat/browser.js
+++ b/src/compat/browser.js
@@ -82,6 +82,14 @@ Monocle.Browser.iOSVersionBelow = function (strOrNum) {
 }
 
 
+if (Monocle.Browser.is.IE) {
+  (function () {
+    var version = navigator.userAgent.match(/(rv:|MSIE )(\d*\.\d*)/)[2];
+    Monocle.Browser.ieVersion = Number(version);
+  })();
+}
+
+
 // Some browser environments are too slow or too problematic for
 // special animation effects.
 //

--- a/src/compat/env.js
+++ b/src/compat/env.js
@@ -420,7 +420,7 @@ Monocle.Env = function () {
     // are rounded.
     //
     ['roundPageDimensions', function () {
-      result(!Monocle.Browser.is.IE);
+      result(!(Monocle.Browser.is.IE && Monocle.Browser.ieVersion < 11));
     }],
 
 


### PR DESCRIPTION
This addresses the recently noticed issue where IE 11 is clipping the right hand side of books
