### PR TITLE
Update img/etc. height for safari

### DIFF
--- a/src/dimensions/columns.js
+++ b/src/dimensions/columns.js
@@ -54,6 +54,7 @@ Monocle.Dimensions.Columns = function (pageDiv) {
       '}',
       'img, video, audio, object, svg {',
         'max-height: '+pdims.height+'px !important;',
+        'height: auto !important;',
       '}'
     ]
 


### PR DESCRIPTION
Added "height: auto !important;" to img, video, audio, object, svg so in Safari the element gets resized preserving the aspect ratio.